### PR TITLE
Add blur effect to GitHub stats and pinned sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,6 +61,13 @@
       gap: 20px;
       margin-top: 20px;
     }
+    .blur-bg {
+      background: rgba(255, 255, 255, 0.05);
+      backdrop-filter: blur(5px);
+      -webkit-backdrop-filter: blur(5px);
+      border-radius: 10px;
+      padding: 1rem;
+    }
     a {
       color: #58a6ff;
       text-decoration: none;
@@ -123,7 +130,7 @@
 
   <div class="section">
     <h2>📊 GitHub Stats</h2>
-    <div class="card-container">
+    <div class="card-container blur-bg">
       <img class="glow-card" src="https://git-hub-streak-stats.vercel.app?user=Nihar16&amp;theme=transparent&amp;hide_border=true&amp;date_format=j%20M%5B%20Y%5D" alt="GitHub Streak" width="380">
       <img class="glow-card" src="https://github-readme-stats.vercel.app/api?username=Nihar16&amp;show_icons=true&amp;theme=transparent&amp;count_private=true&amp;hide_border=true" alt="GitHub Stats" width="380">
     </div>
@@ -131,7 +138,7 @@
 
   <div class="section">
     <h2>📂 Pinned Projects</h2>
-    <div class="card-container" id="pinned-projects">
+    <div class="card-container blur-bg" id="pinned-projects">
       <div class="skeleton"></div>
       <div class="skeleton"></div>
     </div>


### PR DESCRIPTION
## Summary
- add a new CSS class `blur-bg` with backdrop blur styling
- apply `blur-bg` to GitHub Stats container
- apply `blur-bg` to Pinned Projects container

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687650201cb08333982af91ca3f0c91d